### PR TITLE
remove PYTHONPATH from `.env`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,6 @@ python -m pipenv install
 
 Create a `.env` file with these contents:
 ```env
-PYTHONPATH="."
 TOKEN=[insert discord token here]
 ```
 


### PR DESCRIPTION
Fixes #109

(PYTHONPATH doesn't appear to be necessary to resolve imports any more so I removed it from the docs.)