### PR TITLE
Prevent `purge_all_state` on cloud

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-import os, glob, logging
+import os, logging
 import google.cloud.logging
 from models.player import Player
 from models.party import Party

--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 
 description = '''A bot to help strangers make words out of letters'''
 
-if os.environ.get("CLOUD_LOGGING", "off") == "on":
+if os.environ.get("DEPLOYMENT_CONTEXT", "local") == "gce":
     # start up Google Cloud Logging
     client = google.cloud.logging.Client()
     client.get_default_handler()
@@ -145,15 +145,6 @@ async def shuffle(ctx):
 async def purge(ctx):
     player = Player(ctx.author)
     await ctx.send(player.purge())
-
-
-@bot.command(brief='[debug] delete all state', description='FOR DEVELOPMENT ONLY! Delete all state files.')
-async def purge_all_state(ctx):
-    # TODO: make sure this can't run on prod
-    files = glob.glob('.lws/*')
-    for f in files:
-        os.remove(f)
-    await ctx.send("💥 💥 💥 purged ALL state 💥 💥 💥")
 
 
 bot.run(token)

--- a/tools/launch_gce_instance.sh
+++ b/tools/launch_gce_instance.sh
@@ -2,4 +2,4 @@ gcloud beta compute instances create <INSTANCE_NAME> --zone=us-east4-c --machine
     --image-family=debian-10 --image-project=debian-cloud --boot-disk-size=200GB \
     --scopes=https://www.googleapis.com/auth/cloud-platform \
     --metadata-from-file=startup-script=gce_startup_script.sh \
-    --metadata=DATASTORE_NAMESPACE=staging,DISCORD_TOKEN_SECRET_NAME=lws-discord-token-staging,CLOUD_LOGGING=on
+    --metadata=DATASTORE_NAMESPACE=staging,DISCORD_TOKEN_SECRET_NAME=lws-discord-token-staging,DEPLOYMENT_CONTEXT=gce


### PR DESCRIPTION
You know what? Let's just get rid of that command. It's easy enough to delete the files on disk.

Fixes #144